### PR TITLE
Crystal 0.24.1 support

### DIFF
--- a/src/hashids.cr
+++ b/src/hashids.cr
@@ -1,4 +1,5 @@
-require "big_int"
+require "big/big_int"
+require "big/lib_gmp"
 
 class Hashids
   MIN_ALPHABET_LENGTH =   16


### PR DESCRIPTION
Crystal 0.24.1 is out https://github.com/crystal-lang/crystal/releases/tag/v0.24.1

A tiny change is needed to support it by hashids.cr.

Please prepare a new release once you merge it. 