### PR TITLE
min_length -> min_hash_size in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ Here we encode integer 1, and set the minimum hash length to **8**
 (by default it's **0** -- meaning hashes will be the shortest possible length).
 
 ```crystal
-hashids = Hashids.new(salt: "this is my salt", min_length: 8)
+hashids = Hashids.new(salt: "this is my salt", min_hash_size: 8)
 hash = hashids.encode([1]) # => gB0NV05e
 ```
 
 ### Decoding with minimum hash length
 
 ```crystal
-hashids = Hashids.new(salt: "this is my salt", min_length: 8)
+hashids = Hashids.new(salt: "this is my salt", min_hash_size: 8)
 numbers = hashids.decode("gB0NV05e") # => [1]
 ```
 

--- a/examples/from_readme.cr
+++ b/examples/from_readme.cr
@@ -18,10 +18,10 @@ pp hash = hashids.encode([683, 94108, 123, 5]) # => aBMswoO2UB3Sj
 hashids = Hashids.new(salt: "this is my salt")
 pp numbers = hashids.decode("aBMswoO2UB3Sj") # => [683, 94108, 123, 5]
 
-hashids = Hashids.new(salt: "this is my salt", min_length: 8)
+hashids = Hashids.new(salt: "this is my salt", min_hash_size: 8)
 pp hash = hashids.encode([1]) # => gB0NV05e
 
-hashids = Hashids.new(salt: "this is my salt", min_length: 8)
+hashids = Hashids.new(salt: "this is my salt", min_hash_size: 8)
 pp numbers = hashids.decode("gB0NV05e") # => [1]
 
 hashids = Hashids.new(salt: "this is my salt", alphabet: "abcdefghijkABCDEFGHIJK12345")


### PR DESCRIPTION
Readme/examples are out of date on the current parameters for initializing a new `Hashids` object it seems.